### PR TITLE
Making the jekyll cookbook more open

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,3 +34,5 @@ default['jekyll']['gem']['binary'] = nil
 
 default['jekyll']['rbenv']['activated'] = false
 default['jekyll']['rbenv']['version'] = '1.9.3-p194'
+
+default['jekyll']['apache']['enabled'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,7 @@ default['jekyll']['access_rights'] = 0755
 default['jekyll']['domain_name'] = node['fqdn']
 
 default['jekyll']['packages'] = []
+default['jekyll']['command'] = 'jekyll'
 default['jekyll']['options'] = []
 
 default['jekyll']['gem']['source'] = 'https://rubygems.org/'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.1"
+version          "0.1.2"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.4"
+version          "0.1.5"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,9 +3,10 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.1.1"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"
 
 supports         "debian"
+supports	 "centos"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.2"
+version          "0.1.3"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name		 'jekyll'
 maintainer       "Mike Adolphs"
 maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.9"
+version          "0.1.10"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.5"
+version          "0.1.6"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.6"
+version          "0.1.7"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.3"
+version          "0.1.4"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.8"
+version          "0.1.9"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures a Jekyll blog"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.7"
+version          "0.1.8"
 
 depends          "rbenv" # http://fnichol.github.com/chef-rbenv/
 depends          "apache2"

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -10,9 +10,9 @@ end
 # Build command with options if defined for blog generation
 unless node['jekyll']['options'].empty?
   options = node['jekyll']['options'].join(' ')
-  jekyll_command = "jekyll #{options}"
+  jekyll_command = "#{node['jekyll']['command']} #{options}"
 else
-  jekyll_command = "jekyll"
+  jekyll_command = "#{node['jekyll']['command']}"
 end
 
 unless node['jekyll']['rbenv']['activated']

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -26,7 +26,7 @@ unless node['jekyll']['rbenv']['activated']
     cwd node['jekyll']['deploy_directory']
     command "bundle install && #{jekyll_command}"
     action :run
-    not_if File.exists?("#{node['jekyll']['deploy_directory']}/_config.yml")
+    not_if "test -f #{node['jekyll']['deploy_directory']}/_config.yml"
   end
 else
   rbenv_script 'Deploy Jekyll blog' do

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -9,6 +9,8 @@ end
 
 # Build command with options if defined for blog generation
 unless node['jekyll']['options'].empty?
+  options = Array.new
+
   node['jekyll']['options'].each do |opt|
     options << opt.prepend('--')
   end

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -9,12 +9,7 @@ end
 
 # Build command with options if defined for blog generation
 unless node['jekyll']['options'].empty?
-  options = Array.new
-
-  node['jekyll']['options'].each do |opt|
-    options << opt.prepend('--')
-  end
-  jeckyll_options = options.join(' ')
+  options = node['jekyll']['options'].join(' ')
   jekyll_command = "jekyll #{options}"
 else
   jekyll_command = "jekyll"

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -24,9 +24,9 @@ end
 unless node['jekyll']['rbenv']['activated']
   execute 'Deploy Jekyll blog' do
     cwd node['jekyll']['deploy_directory']
-    command "bundle install && #{jekyll_command}"
+    command "bundle install && #{jekyll_command} && touch /var/chef/cache/jekyll_bootstrapped"
     action :run
-    not_if "test -f #{node['jekyll']['deploy_directory']}/_config.yml"
+    not_if "test -f /var/chef/cache/jekyll_bootstrapped"
   end
 else
   rbenv_script 'Deploy Jekyll blog' do

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -10,7 +10,7 @@ git node['jekyll']['deploy_directory'] do
   user node['jekyll']['user']
   group node['jekyll']['group']
   action :sync 
-  notifies :run, execute['jekyll-build'], :immediately
+  notifies :run, 'execute[jekyll-build]', :immediately
 end
 
 # Build command with options if defined for blog generation

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -9,8 +9,10 @@ end
 
 # Build command with options if defined for blog generation
 unless node['jekyll']['options'].empty?
-  options = node['jekyll']['options'].each { |opt| opt.prepend('--')}
-  options = options.join(' ')
+  options = node['jekyll']['options'].each do |opt|
+    opt.prepend('--')
+  end
+  jeckyll_options = options.join(' ')
   jekyll_command = "jekyll #{options}"
 else
   jekyll_command = "jekyll"

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -2,6 +2,7 @@ execute "jekyll-build" do
   cwd node['jekyll']['deploy_directory']
   command "jekyll build"
   action :nothing
+  only_if "test -f /var/chef/cache/jekyll_bootstrapped"
 end
 
 git node['jekyll']['deploy_directory'] do
@@ -9,7 +10,7 @@ git node['jekyll']['deploy_directory'] do
   reference node['jekyll']['reference']
   user node['jekyll']['user']
   group node['jekyll']['group']
-  action :sync 
+  action :sync
   notifies :run, 'execute[jekyll-build]', :immediately
 end
 

--- a/recipes/_deploy_blog.rb
+++ b/recipes/_deploy_blog.rb
@@ -9,8 +9,8 @@ end
 
 # Build command with options if defined for blog generation
 unless node['jekyll']['options'].empty?
-  options = node['jekyll']['options'].each do |opt|
-    opt.prepend('--')
+  node['jekyll']['options'].each do |opt|
+    options << opt.prepend('--')
   end
   jeckyll_options = options.join(' ')
   jekyll_command = "jekyll #{options}"

--- a/recipes/_setup_webserver.rb
+++ b/recipes/_setup_webserver.rb
@@ -1,3 +1,5 @@
+return if node['jekyll']['apache']['enabled'] == false
+
 domain_name = node['jekyll']['domain_name']
 
 web_app "jekyll-#{domain_name}" do


### PR DESCRIPTION
1. Add cookbook name to metadata to satisfy warnings
2. Add default jekyll command to attributes
3. Rework the logic around jekyll options to satisfy warnings from chef
4. remove the join of '--' in front of the option since some options don't have the '--' prefix
5. Add a toggle switch for installing/configuring apache2 to make it more open to other configurations, such as serving jekyll up from the built-in web server
6. Tested on CentOS 7 